### PR TITLE
修复parse_web中未找到搜索数量的报错

### DIFF
--- a/baiduspider/parser/__init__.py
+++ b/baiduspider/parser/__init__.py
@@ -46,9 +46,12 @@ class Parser(BaseSpider):
             if found:
                 break
             idx_ += 1
-        num = int(
-            str(ele.text).strip("百度为您找到相关结果").strip("约").strip("个").replace(",", "")
-        )
+        try:
+            num = int(
+                str(ele.text).strip("百度为您找到相关结果").strip("约").strip("个").replace(",", "")
+            )
+        except:
+            warnings.warn("未找到搜索结果数量")
         # 定义预结果（运算以及相关搜索）
         pre_results = []
         # 预处理新闻
@@ -311,7 +314,7 @@ class Parser(BaseSpider):
             "results": result,
             # 最大页数
             # "pages": max(pages),
-            "total": num,
+            "total": len(result),
         }
 
     def parse_web_normal(self, content: str, exclude: list) -> dict:


### PR DESCRIPTION
首先，感谢你来提交 PR！🎉🎉🎉

请你填写下面的信息，然后提交该请求。

**你在该请求中做了些什么？**

修复bug。

最近的一次commit在`parse_web_normal`里获取`百度为您找到相关结果约xxx个`处修复了可能找不到xxx的问题。

但是在第50行`parse_web`中没有修改，此PR修复了这个问题。

**你的代码的缺点（可能出现的bug）**

请描述。

**对请求的详细描述**

请填写。
